### PR TITLE
Fix ordering for java command line arguments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export default class SQSLocal {
     const args = ['-jar', this.jarname]
 
     if (this.configFile) {
-      args.push('-Dconfig.file=' + this.configFile)
+      args.unshift('-Dconfig.file=' + this.configFile)
     }
     if (this.process) {
       return this.process


### PR DESCRIPTION
Java options (such as -D to specify a system property) must come prior to specifying a JAR file:
https://manpages.debian.org/unstable/openjdk-19-jre-headless/java.1.en.html

If they come after the JAR file, they are treated as arguments to the main class instead.

As a result, the `configFile` option was previously ignored.